### PR TITLE
Minor rebase fixes and some cleanup

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -72,8 +72,8 @@ GRS_OBJS = \
     $(END)
 # removed object files from here 
 
-# The compiler itself is called grs1
-grs1$(exeext): $(GRS_OBJS) attribs.o  $(BACKEND) $(LIBDEPS)
+# The compiler itself is called rust1 (formerly grs1)
+rust1$(exeext): $(GRS_OBJS) attribs.o  $(BACKEND) $(LIBDEPS)
 	+$(LLINKER) $(ALL_LINKERFLAGS) $(LDFLAGS) -o $@ \
 	      $(GRS_OBJS) attribs.o $(BACKEND) $(LIBS) $(BACKENDLIBS)
 

--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -30,7 +30,7 @@ GCCRS_INSTALL_NAME := $(shell echo gccrs|sed '$(program_transform_name)')
 GCCRS_TARGET_INSTALL_NAME := $(target_noncanonical)-$(shell echo gccrs|sed '$(program_transform_name)')
 
 # Define the names for selecting rust in LANGUAGES.
-rust: gccrs$(exeext) grs1$(exeext)
+rust: gccrs$(exeext) rust1$(exeext)
 
 # Tell GNU make to ignore files by these names if they exist.
 .PHONY: rust

--- a/gcc/rust/ast/rust-ast-full-test.cc
+++ b/gcc/rust/ast/rust-ast-full-test.cc
@@ -2128,7 +2128,7 @@ namespace Rust {
             // kind of a HACK to get locus depending on opening scope resolution
             Location locus = Linemap::unknown_location();
             if (with_opening_scope_resolution) {
-                locus = simple_segments[0].get_locus()/* - 2*/; // minus 2 chars for ::
+                locus = simple_segments[0].get_locus() - 2; // minus 2 chars for ::
             } else {
                 locus = simple_segments[0].get_locus();
             }
@@ -3455,7 +3455,8 @@ namespace Rust {
                         return parse_path_meta_item();
                     }
                     default:
-                        rust_error_at(peek_token()->get_locus(), "unrecognised token '%s' in meta item",
+                        rust_error_at(peek_token()->get_locus(),
+                          "unrecognised token '%s' in meta item",
                           get_token_description(peek_token()->get_id()));
                         return NULL;
                 }
@@ -3578,7 +3579,8 @@ namespace Rust {
                     Location locus = peek_token()->get_locus();
                     Literal lit = parse_literal();
                     if (lit.is_error()) {
-                        rust_error_at(peek_token()->get_locus(), "failed to parse literal in attribute");
+                        rust_error_at(
+                          peek_token()->get_locus(), "failed to parse literal in attribute");
                         return NULL;
                     }
                     LiteralExpr expr(::std::move(lit), locus);
@@ -3916,25 +3918,11 @@ namespace Rust {
         }
 
         bool MetaNameValueStr::check_cfg_predicate(const Session& session) const {
-            auto it = session.options.target_data.features.find(ident);
-            if (it != session.options.target_data.features.end()) {
-                // value must also be the same, not just the name existing
-                if (it->second.find(str) != it->second.end()) {
-                    return true;
-                }
-            }
-            return false;
+            return session.options.target_data.has_key_value_pair(ident, str);
         }
 
         bool MetaItemPathLit::check_cfg_predicate(const Session& session) const {
-            auto it = session.options.target_data.features.find(path.as_string());
-            if (it != session.options.target_data.features.end()) {
-                // value must also be the same, not just the name existing
-                if (it->second.find(lit.as_string()) != it->second.end()) {
-                    return true;
-                }
-            }
-            return false;
+            return session.options.target_data.has_key_value_pair(path.as_string(), lit.as_string());
         }
 
         ::std::vector< ::std::unique_ptr<Token> > Token::to_token_stream() const {

--- a/gcc/rust/ast/rust-ast.h
+++ b/gcc/rust/ast/rust-ast.h
@@ -9,10 +9,13 @@
 #include "system.h"
 #include "coretypes.h" // order: config, INCLUDE, system, coretypes
 
-// STL imports
 #include "rust-system.h"
+
+// STL imports
 // with C++11, now can use actual std::unique_ptr
 #include <memory>
+#include <string>
+#include <vector>
 
 // gccrs imports
 // required for AST::Token
@@ -156,10 +159,8 @@ namespace Rust {
             }
 
             // constructor from general text - avoid using if lexer const_TokenPtr is available
-            Token(
-              TokenId token_id, Location locus, ::std::string str, PrimitiveCoreType type_hint) :
-              token_id(token_id),
-              locus(locus), str(::std::move(str)), type_hint(type_hint) {}
+            Token(TokenId token_id, Location locus, ::std::string str, PrimitiveCoreType type_hint) :
+              token_id(token_id), locus(locus), str(::std::move(str)), type_hint(type_hint) {}
 
             // Constructor from lexer const_TokenPtr
             /* TODO: find workaround for std::string being NULL - probably have to introduce new
@@ -276,11 +277,11 @@ namespace Rust {
             // reference - will be cleaner Parse a meta item inner.
             //::std::unique_ptr<MetaItemInner> parse_meta_item_inner(const ::std::vector<
             //::std::unique_ptr<Token> >& token_stream, int& i) const; SimplePath
-            // parse_simple_path(const ::std::vector< ::std::unique_ptr<Token> >& token_stream, int& i)
-            // const; SimplePathSegment parse_simple_path_segment(const ::std::vector<
+            // parse_simple_path(const ::std::vector< ::std::unique_ptr<Token> >& token_stream, int&
+            // i) const; SimplePathSegment parse_simple_path_segment(const ::std::vector<
             // ::std::unique_ptr<Token> >& token_stream, int& i) const;
             //::std::unique_ptr<MetaItemLitExpr> parse_meta_item_lit(const ::std::unique_ptr<Token>&
-            //tok) const;
+            // tok) const;
             //::std::vector< ::std::unique_ptr<MetaItemInner> > parse_meta_item_seq(const
             //::std::vector< ::std::unique_ptr<Token> >& token_stream, int& i) const; Literal
             // parse_literal(const ::std::unique_ptr<Token>& tok) const;
@@ -301,12 +302,12 @@ namespace Rust {
 
           public:
             DelimTokenTree(DelimType delim_type,
-                           ::std::vector< ::std::unique_ptr<TokenTree> > token_trees
-                           = ::std::vector< ::std::unique_ptr<TokenTree> >(),
-                           Location locus = Location()) :
-                delim_type(delim_type),
-                token_trees(::std::move(token_trees)), locus(locus) {}
-            
+              ::std::vector< ::std::unique_ptr<TokenTree> > token_trees
+              = ::std::vector< ::std::unique_ptr<TokenTree> >(),
+              Location locus = Location()) :
+              delim_type(delim_type),
+              token_trees(::std::move(token_trees)), locus(locus) {}
+
             // Copy constructor with vector clone
             DelimTokenTree(DelimTokenTree const& other) :
               delim_type(other.delim_type), locus(other.locus) {
@@ -468,8 +469,8 @@ namespace Rust {
             }
 
             // Constructor has pointer AttrInput for polymorphism reasons
-            Attribute(SimplePath path, ::std::unique_ptr<AttrInput> input,
-              Location locus = Location()) :
+            Attribute(
+              SimplePath path, ::std::unique_ptr<AttrInput> input, Location locus = Location()) :
               path(::std::move(path)),
               attr_input(::std::move(input)), locus(locus) {}
 
@@ -1000,8 +1001,8 @@ namespace Rust {
 
           public:
             // Constructor
-            Lifetime(LifetimeType type, ::std::string name = ::std::string(),
-              Location locus = Location()) :
+            Lifetime(
+              LifetimeType type, ::std::string name = ::std::string(), Location locus = Location()) :
               lifetime_type(type),
               lifetime_name(::std::move(name)), locus(locus) {}
 

--- a/gcc/rust/ast/rust-cond-compilation.h
+++ b/gcc/rust/ast/rust-cond-compilation.h
@@ -116,11 +116,11 @@ namespace Rust {
                 return *this;
             }
 
-            // move constructors 
+            // move constructors
             ConfigurationNot(ConfigurationNot&& other) = default;
             ConfigurationNot& operator=(ConfigurationNot&& other) = default;
 
-          virtual void accept_vis(ASTVisitor& vis) OVERRIDE;
+            virtual void accept_vis(ASTVisitor& vis) OVERRIDE;
 
           protected:
             // Use covariance to implement clone function as returning this object rather than base
@@ -150,13 +150,14 @@ namespace Rust {
                 return *this;
             }
 
-            // move constructors 
+            // move constructors
             CfgAttribute(CfgAttribute&& other) = default;
             CfgAttribute& operator=(CfgAttribute&& other) = default;
         };
-        /* TODO: ok, best thing to do would be eliminating this class, making Attribute has a "is_cfg()"
-         * method, and having attribute path as "cfg" and AttrInput as ConfigurationPredicate (so make
-         * ConfigurationPredicate a subclass of AttrInput?). Would need special handling in parser, however. */
+        /* TODO: ok, best thing to do would be eliminating this class, making Attribute has a
+         * "is_cfg()" method, and having attribute path as "cfg" and AttrInput as
+         * ConfigurationPredicate (so make ConfigurationPredicate a subclass of AttrInput?). Would
+         * need special handling in parser, however. */
 
         // TODO: inline
         struct CfgAttrs {
@@ -189,7 +190,7 @@ namespace Rust {
                 return *this;
             }
 
-            // move constructors 
+            // move constructors
             CfgAttrAttribute(CfgAttrAttribute&& other) = default;
             CfgAttrAttribute& operator=(CfgAttrAttribute&& other) = default;
         };

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -198,7 +198,8 @@ namespace Rust {
             virtual void accept_vis(ASTVisitor& vis) OVERRIDE;
 
             virtual bool check_cfg_predicate(const Session& session) const OVERRIDE;
-            // TODO: return true if "ident" is defined and value of it is "lit", return false otherwise
+            // TODO: return true if "ident" is defined and value of it is "lit", return false
+            // otherwise
 
           protected:
             // Use covariance to implement clone function as returning this type
@@ -1865,8 +1866,8 @@ namespace Rust {
                 // return struct_name.as_string();
             }
 
-            StructExprUnit(PathInExpression struct_path, ::std::vector<Attribute> outer_attribs,
-              Location locus) :
+            StructExprUnit(
+              PathInExpression struct_path, ::std::vector<Attribute> outer_attribs, Location locus) :
               StructExpr(::std::move(struct_path), ::std::move(outer_attribs)),
               locus(locus) {}
 
@@ -2893,8 +2894,7 @@ namespace Rust {
 
           protected:
             // outer attributes not allowed before range expressions
-            RangeExpr(Location locus) :
-              ExprWithoutBlock(::std::vector<Attribute>()), locus(locus) {}
+            RangeExpr(Location locus) : ExprWithoutBlock(::std::vector<Attribute>()), locus(locus) {}
 
           public:
             Location get_locus() const {
@@ -2922,8 +2922,8 @@ namespace Rust {
 
             ::std::string as_string() const;
 
-            RangeFromToExpr(::std::unique_ptr<Expr> range_from, ::std::unique_ptr<Expr> range_to,
-              Location locus) :
+            RangeFromToExpr(
+              ::std::unique_ptr<Expr> range_from, ::std::unique_ptr<Expr> range_to, Location locus) :
               RangeExpr(locus),
               from(::std::move(range_from)), to(::std::move(range_to)) {}
 
@@ -3095,8 +3095,8 @@ namespace Rust {
 
             ::std::string as_string() const;
 
-            RangeFromToInclExpr(::std::unique_ptr<Expr> range_from, ::std::unique_ptr<Expr> range_to,
-              Location locus) :
+            RangeFromToInclExpr(
+              ::std::unique_ptr<Expr> range_from, ::std::unique_ptr<Expr> range_to, Location locus) :
               RangeExpr(locus),
               from(::std::move(range_from)), to(::std::move(range_to)) {}
             // outer attributes not allowed
@@ -3860,8 +3860,7 @@ namespace Rust {
             ::std::string as_string() const;
 
             IfLetExpr(::std::vector< ::std::unique_ptr<Pattern> > match_arm_patterns,
-              ::std::unique_ptr<Expr> value, ::std::unique_ptr<BlockExpr> if_block,
-              Location locus) :
+              ::std::unique_ptr<Expr> value, ::std::unique_ptr<BlockExpr> if_block, Location locus) :
               ExprWithBlock(::std::vector<Attribute>()),
               match_arm_patterns(::std::move(match_arm_patterns)), value(::std::move(value)),
               if_block(::std::move(if_block)), locus(locus) {}

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1697,10 +1697,9 @@ namespace Rust {
                 return !outer_attrs.empty();
             }
 
-            EnumItem(
-              Identifier variant_name, ::std::vector<Attribute> outer_attrs, Location locus) :
-              outer_attrs(::std::move(outer_attrs)),
-              variant_name(::std::move(variant_name)), locus(locus) {}
+            EnumItem(Identifier variant_name, ::std::vector<Attribute> outer_attrs, Location locus) :
+              outer_attrs(::std::move(outer_attrs)), variant_name(::std::move(variant_name)),
+              locus(locus) {}
 
             // Unique pointer custom clone function
             ::std::unique_ptr<EnumItem> clone_enum_item() const {

--- a/gcc/rust/ast/rust-macro.h
+++ b/gcc/rust/ast/rust-macro.h
@@ -288,8 +288,7 @@ namespace Rust {
             ::std::string as_string() const;
 
             MacroRulesDefinition(Identifier rule_name, DelimType delim_type,
-              ::std::vector<MacroRule> rules, ::std::vector<Attribute> outer_attrs,
-              Location locus) :
+              ::std::vector<MacroRule> rules, ::std::vector<Attribute> outer_attrs, Location locus) :
               MacroItem(::std::move(outer_attrs)),
               rule_name(::std::move(rule_name)), delim_type(delim_type), rules(::std::move(rules)),
               locus(locus) {}
@@ -377,7 +376,7 @@ namespace Rust {
                 return path;
             }
 
-            virtual bool check_cfg_predicate(const Session& session) const OVERRIDE; 
+            virtual bool check_cfg_predicate(const Session& session) const OVERRIDE;
 
           protected:
             // Use covariance to implement clone function as returning this type
@@ -451,7 +450,7 @@ namespace Rust {
 
             virtual void accept_vis(ASTVisitor& vis) OVERRIDE;
 
-            virtual bool check_cfg_predicate(const Session& session) const OVERRIDE; 
+            virtual bool check_cfg_predicate(const Session& session) const OVERRIDE;
 
           protected:
             // Use covariance to implement clone function as returning this type
@@ -480,7 +479,7 @@ namespace Rust {
                 return clone_meta_item_inner_impl();
             }
 
-            virtual bool check_cfg_predicate(const Session& session) const OVERRIDE; 
+            virtual bool check_cfg_predicate(const Session& session) const OVERRIDE;
 
           protected:
             // Use covariance to implement clone function as returning this type

--- a/gcc/rust/ast/rust-path.h
+++ b/gcc/rust/ast/rust-path.h
@@ -29,7 +29,8 @@ namespace Rust {
             /* TODO: insert check in constructor for this? Or is this a semantic error best handled
              * then? */
 
-            // TODO: does this require visitor. pretty sure this isn't polymorphic, but not entirely sure
+            // TODO: does this require visitor. pretty sure this isn't polymorphic, but not entirely
+            // sure
 
             // Creates an error PathIdentSegment.
             static PathIdentSegment create_error() {
@@ -67,8 +68,8 @@ namespace Rust {
             }
 
             // Pointer type for type in constructor to enable polymorphism
-            GenericArgsBinding(Identifier ident, ::std::unique_ptr<Type> type_ptr,
-              Location locus = Location()) :
+            GenericArgsBinding(
+              Identifier ident, ::std::unique_ptr<Type> type_ptr, Location locus = Location()) :
               identifier(::std::move(ident)),
               type(::std::move(type_ptr)), locus(locus) {}
 
@@ -326,8 +327,8 @@ namespace Rust {
                 return ::std::unique_ptr<TypePathSegment>(clone_type_path_segment_impl());
             }
 
-            TypePathSegment(PathIdentSegment ident_segment, bool has_separating_scope_resolution,
-              Location locus) :
+            TypePathSegment(
+              PathIdentSegment ident_segment, bool has_separating_scope_resolution, Location locus) :
               ident_segment(::std::move(ident_segment)),
               locus(locus), has_separating_scope_resolution(has_separating_scope_resolution) {}
 
@@ -496,8 +497,7 @@ namespace Rust {
           public:
             // Constructor with PathIdentSegment and TypePathFn
             TypePathSegmentFunction(PathIdentSegment ident_segment,
-              bool has_separating_scope_resolution, TypePathFunction function_path,
-              Location locus) :
+              bool has_separating_scope_resolution, TypePathFunction function_path, Location locus) :
               TypePathSegment(::std::move(ident_segment), has_separating_scope_resolution, locus),
               function_path(::std::move(function_path)) {}
 
@@ -554,16 +554,12 @@ namespace Rust {
 
             // Creates an error state TypePath.
             static TypePath create_error() {
-                return TypePath(
-                    ::std::vector< ::std::unique_ptr<TypePathSegment> >(),
-                    Linemap::unknown_location(),
-                    false);
+                return TypePath(::std::vector< ::std::unique_ptr<TypePathSegment> >(), Location());
             }
 
             // Constructor
-            TypePath(::std::vector< ::std::unique_ptr<TypePathSegment> > segments,
-                     Location locus,
-                     bool has_opening_scope_resolution = false) :
+            TypePath(::std::vector< ::std::unique_ptr<TypePathSegment> > segments, Location locus,
+              bool has_opening_scope_resolution = false) :
               has_opening_scope_resolution(has_opening_scope_resolution),
               segments(::std::move(segments)), locus(locus) {}
 
@@ -625,8 +621,8 @@ namespace Rust {
 
           public:
             // Constructor
-            QualifiedPathType(::std::unique_ptr<Type> invoke_on_type,
-              Location locus = Location(), TypePath trait_path = TypePath::create_error()) :
+            QualifiedPathType(::std::unique_ptr<Type> invoke_on_type, Location locus = Location(),
+              TypePath trait_path = TypePath::create_error()) :
               type_to_invoke_on(::std::move(invoke_on_type)),
               trait_path(::std::move(trait_path)), locus(locus) {}
 

--- a/gcc/rust/ast/rust-type.h
+++ b/gcc/rust/ast/rust-type.h
@@ -68,8 +68,8 @@ namespace Rust {
             }
 
           public:
-            ImplTraitType(::std::vector< ::std::unique_ptr<TypeParamBound> > type_param_bounds,
-              Location locus) :
+            ImplTraitType(
+              ::std::vector< ::std::unique_ptr<TypeParamBound> > type_param_bounds, Location locus) :
               type_param_bounds(::std::move(type_param_bounds)),
               locus(locus) {}
 
@@ -480,8 +480,8 @@ namespace Rust {
             }
 
             // Constructor
-            ReferenceType(bool is_mut, ::std::unique_ptr<TypeNoBounds> type_no_bounds,
-              Location locus, Lifetime lifetime = Lifetime::error()) :
+            ReferenceType(bool is_mut, ::std::unique_ptr<TypeNoBounds> type_no_bounds, Location locus,
+              Lifetime lifetime = Lifetime::error()) :
               lifetime(::std::move(lifetime)),
               has_mut(is_mut), type(::std::move(type_no_bounds)), locus(locus) {}
 

--- a/gcc/rust/backend.h
+++ b/gcc/rust/backend.h
@@ -1,10 +1,13 @@
-#pragma once
+#ifndef RUST_BACKEND_H
+#define RUST_BACKEND_H
 
 #include <gmp.h>
 #include <mpfr.h>
 #include <mpc.h>
 
 #include "operator.h"
+
+// TODO: Will have to be significantly modified to work with Rust and current setup of gccrs
 
 // Pointers to these types are created by the backend, passed to the
 // frontend, and passed back to the backend.  The types must be
@@ -776,3 +779,5 @@ class Backend
   virtual void
   write_export_data(const char* bytes, unsigned int size) = 0;
 };
+
+#endif // RUST_BACKEND_H

--- a/gcc/rust/lex/rust-lex.h
+++ b/gcc/rust/lex/rust-lex.h
@@ -30,20 +30,22 @@ namespace Rust {
         // ok maybe all these may mean the lexer structure needs to be rethought
         /* separated into functions because main method was too long, but they rely on and change
          * state in the lexer, so variables must be passed by reference. */
-        inline void parse_in_decimal(/*char& current_char, */std::string& str, int& length);
-        inline void parse_in_exponent_part(/*char& current_char, */std::string& str, int& length);
+        inline void parse_in_decimal(/*char& current_char, */ std::string& str, int& length);
+        inline void parse_in_exponent_part(/*char& current_char, */ std::string& str, int& length);
         inline bool parse_in_type_suffix(
-          /*char& current_char, */PrimitiveCoreType& type_hint, int& length);
-        inline bool parse_ascii_escape(/*char& current_char, */int& length, char& output_char);
-        inline bool parse_quote_escape(/*char& current_char, */int& length, char& output_char);
-        inline bool parse_unicode_escape(/*char& current_char, */int& length, Codepoint& output_char);
-        inline bool parse_byte_escape(/*char& current_char, */int& length, char& output_char);
+          /*char& current_char, */ PrimitiveCoreType& type_hint, int& length);
+        inline bool parse_ascii_escape(/*char& current_char, */ int& length, char& output_char);
+        inline bool parse_quote_escape(/*char& current_char, */ int& length, char& output_char);
+        inline bool parse_unicode_escape(
+          /*char& current_char, */ int& length, Codepoint& output_char);
+        inline bool parse_byte_escape(/*char& current_char, */ int& length, char& output_char);
         inline bool parse_escape(int& length, char& output_char, char opening_char);
         inline bool parse_utf8_escape(int& length, Codepoint& output_char, char opening_char);
         inline int test_get_input_codepoint_length();
         inline int test_get_input_codepoint_n_length(int n_start_offset);
         inline Codepoint test_peek_codepoint_input();
-        inline Codepoint test_peek_codepoint_input(int n); // maybe can use get_input_codepoint_length to get starting index
+        inline Codepoint test_peek_codepoint_input(
+          int n); // maybe can use get_input_codepoint_length to get starting index
         inline void test_skip_codepoint_input();
 
       public:
@@ -64,7 +66,9 @@ namespace Rust {
         // Replaces the current token with a specified token.
         void replace_current_token(TokenPtr replacement);
 
-        Linemap* get_line_map() { return line_map; }
+        Linemap* get_line_map() {
+            return line_map;
+        }
 
       private:
         // File for use as input.

--- a/gcc/rust/operator.h
+++ b/gcc/rust/operator.h
@@ -9,6 +9,8 @@
 
 // The operators.
 
+// TODO: Will have to be significantly modified to work with Rust and current setup of gccrs
+
 enum Operator
 {
   OPERATOR_INVALID,

--- a/gcc/rust/rust-backend.c
+++ b/gcc/rust/rust-backend.c
@@ -30,7 +30,10 @@ along with GCC; see the file COPYING3.  If not see
 #include "intl.h"
 #include "output.h"	/* for assemble_string */
 #include "common/common-target.h"
-#include "rust-c.h"
+//#include "rust-c.h" // import no longer exists, so hopefully not broken
+
+// satisfy intellisense
+#include "options.h"
 
 /* The segment name we pass to simple_object_start_read to find Rust
    export data.  */
@@ -84,7 +87,7 @@ rust_field_alignment (tree t)
 /* This is called by the Rust frontend proper if the unsafe package was
    imported.  When that happens we cannot do type-based alias
    analysis.  */
-
+// TODO: this should be removed, as it only pertains to Go, not Rust
 void
 rust_imported_unsafe (void)
 {

--- a/gcc/rust/rust-gcc.cc
+++ b/gcc/rust/rust-gcc.cc
@@ -48,6 +48,8 @@
 #include "backend.h"
 #include "rust-object-export.h"
 
+// TODO: this will have to be significantly modified to work with Rust
+
 // A class wrapping a tree.
 
 class Gcc_tree

--- a/gcc/rust/rust-lang.cc
+++ b/gcc/rust/rust-lang.cc
@@ -265,9 +265,9 @@ static bool grs_langhook_post_options(const char** pfilename ATTRIBUTE_UNUSED) {
 static int grs_langhook_gimplify_expr(tree* expr_p ATTRIBUTE_UNUSED,
   gimple_seq* pre_p ATTRIBUTE_UNUSED, gimple_seq* post_p ATTRIBUTE_UNUSED) {
     if (TREE_CODE (*expr_p) == CALL_EXPR
-        && CALL_EXPR_STATIC_CHAIN (*expr_p) != NULL_TREE)
+      && CALL_EXPR_STATIC_CHAIN (*expr_p) != NULL_TREE)
         gimplify_expr (&CALL_EXPR_STATIC_CHAIN (*expr_p), pre_p, post_p,
-                       is_gimple_val, fb_rvalue);
+          is_gimple_val, fb_rvalue);
     return GS_UNHANDLED;
 }
 

--- a/gcc/rust/rust-linemap.h
+++ b/gcc/rust/rust-linemap.h
@@ -22,6 +22,11 @@
 // The Linemap class is a pure abstract interface, plus some static
 // convenience functions.  The backend must implement the interface.
 
+/* TODO: probably better to replace linemap implementation as pure abstract interface with some sort of 
+ * compile-time switch (macros or maybe templates if doable without too much extra annoyance) as to the
+ * definition of the methods or whatever. This is to improve performance, as virtual function calls would
+ * otherwise have to be made in tight loops like in the lexer. */
+
 class Linemap
 {
  public:

--- a/gcc/rust/rust-location.h
+++ b/gcc/rust/rust-location.h
@@ -20,7 +20,24 @@ class Location
 
   location_t
   gcc_location() const
-  { return this->gcc_loc_; }
+  { return gcc_loc_; }
+
+  Location 
+  operator+=(location_t rhs) {
+    gcc_loc_ += rhs;
+    return *this;
+  }
+
+  Location 
+  operator-=(location_t rhs) {
+    gcc_loc_ -= rhs;
+    return *this;
+  }
+
+  bool 
+  operator==(location_t rhs) {
+    return rhs == gcc_loc_;
+  }
 
  private:
   location_t gcc_loc_;
@@ -38,6 +55,20 @@ inline bool
 operator==(Location loca, Location locb)
 {
   return loca.gcc_location() == locb.gcc_location();
+}
+
+inline Location 
+operator+(Location lhs, location_t rhs) 
+{
+  lhs += rhs;
+  return lhs;
+}
+
+inline Location 
+operator-(Location lhs, location_t rhs) 
+{
+  lhs -= rhs;
+  return lhs;
 }
 
 #endif // !defined(RUST_LOCATION_H)

--- a/gcc/rust/rust-object-export.c
+++ b/gcc/rust/rust-object-export.c
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with GCC; see the file COPYING3.  If not see
 <http://www.gnu.org/licenses/>.  */
 
+// FIXME: doesn't this duplicate lots of code from rust-backend.c? Is one meant to be a replacement?
+
 #include "config.h"
 #include "system.h"
 #include "coretypes.h"
@@ -30,6 +32,9 @@ along with GCC; see the file COPYING3.  If not see
 #include "intl.h"
 #include "output.h"	/* for assemble_string */
 #include "common/common-target.h"
+
+// satisfy intellisense
+#include "options.h"
 
 /* The segment name we pass to simple_object_start_read to find Rust
    export data.  */
@@ -83,7 +88,7 @@ rust_field_alignment (tree t)
 /* This is called by the Rust frontend proper if the unsafe package was
    imported.  When that happens we cannot do type-based alias
    analysis.  */
-
+// TODO: this should be removed, as it only pertains to Go, not Rust
 void
 rust_imported_unsafe (void)
 {

--- a/gcc/rust/rust-object-export.h
+++ b/gcc/rust/rust-object-export.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef RUST_OBJECT_EXPORT_H
+#define RUST_OBJECT_EXPORT_H
 
 extern unsigned int rust_field_alignment (tree t);
 
@@ -7,3 +8,5 @@ rust_read_export_data (int fd, off_t offset, char **pbuf, size_t *plen,
                        int *perr);
 extern void
 rust_write_export_data (const char *bytes, unsigned int size);
+
+#endif // RUST_OBJECT_EXPORT_H

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -518,12 +518,8 @@ namespace Rust {
 
             // create "extern crate" item with the name
             ::std::unique_ptr<AST::ExternCrate> extern_crate(
-                new AST::ExternCrate(
-                    *it,
-                    AST::Visibility::create_error(),
-                    { ::std::move(attr) },
-                    Linemap::unknown_location())
-                );
+              new AST::ExternCrate(*it, AST::Visibility::create_error(), { ::std::move(attr) },
+              Linemap::unknown_location()));
 
             // insert at beginning
             crate.items.insert(crate.items.begin(), ::std::move(extern_crate));
@@ -536,10 +532,10 @@ namespace Rust {
                 AST::SimplePathSegment("v1") };
         // create use tree and decl
         ::std::unique_ptr<AST::UseTreeGlob> use_tree(new AST::UseTreeGlob(
-          AST::UseTreeGlob::PATH_PREFIXED, AST::SimplePath(::std::move(segments)), Linemap::unknown_location()));
+          AST::UseTreeGlob::PATH_PREFIXED, AST::SimplePath(::std::move(segments)), Location()));
         AST::Attribute prelude_attr(AST::SimplePath::from_str("prelude_import"), NULL);
         ::std::unique_ptr<AST::UseDeclaration> use_decl(new AST::UseDeclaration(::std::move(use_tree),
-          AST::Visibility::create_error(), { ::std::move(prelude_attr) }, Linemap::unknown_location()));
+          AST::Visibility::create_error(), { ::std::move(prelude_attr) }, Location()));
 
         crate.items.insert(crate.items.begin(), ::std::move(use_decl));
 

--- a/gcc/rust/rust-session-manager.h
+++ b/gcc/rust/rust-session-manager.h
@@ -11,6 +11,10 @@
 #include "rust-linemap.h"
 #include "backend.h"
 
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 #include <utility>
 
 namespace Rust {
@@ -144,6 +148,8 @@ namespace Rust {
 
         // backend linemap
         Linemap* linemap;
+
+        // TODO: replace raw pointers with smart pointers?
 
       public:
         /* Initialise compiler session. Corresponds to langhook grs_langhook_init(). Note that this is

--- a/gcc/rust/rust-system.h
+++ b/gcc/rust/rust-system.h
@@ -41,6 +41,9 @@
 #include <deque>
 #include <functional>
 
+/* TODO: strictly speaking, as AST move semantics make frontend C++11-and-up only, unordered map should
+ * always be definable (i.e. don't have to resort to tr1 like in C++03), so don't need to have this
+ * macro switch - just include <unordered_map> and <unordered_set>. */
 #if defined(HAVE_UNORDERED_MAP)
 
 # include <unordered_map>

--- a/gcc/rust/rustspec.cc
+++ b/gcc/rust/rustspec.cc
@@ -23,6 +23,9 @@ along with GCC; see the file COPYING3.  If not see
 #include "tm.h"
 #include "opts.h"
 
+// satisfy intellisense
+#include "options.h"
+
 /* This bit is set if we saw a `-xfoo' language specification.  */
 #define LANGSPEC	(1<<1)
 /* This bit is set if they did `-lm' or `-lmath'.  */


### PR DESCRIPTION
Changes consist of some rebase issue fixes and some cleanup of code.

The more important fixes are:
- actually allows the gccrs compiler driver to run something (fixes the mismatch between the old "grs1" and new "rust1" compiler names) - otherwise the gccrs compiler driver fails to work 
- readded the location adjustments when parsing (i.e. the "locus - 2" instead of just "locus")
- minor changes to satisfy intellisense (and other static analysis) via adding header includes

Also, this is the first test for new PR-based contributing system - we can set a precedent on standards or best practices or whatever.