### PR TITLE
Add rust_OBJS to fix compiling error

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -72,6 +72,8 @@ GRS_OBJS = \
     $(END)
 # removed object files from here 
 
+rust_OBJS = $(GRS_OBJS) rust/rustspec.o
+
 # The compiler itself is called rust1 (formerly grs1)
 rust1$(exeext): $(GRS_OBJS) attribs.o  $(BACKEND) $(LIBDEPS)
 	+$(LLINKER) $(ALL_LINKERFLAGS) $(LDFLAGS) -o $@ \


### PR DESCRIPTION
The Makefile of gcc directory will iterate `lang_OBJS` variable for detecting language frontend objects, so the standard way is to define this variable with all related object filenames.

Besides, the missing of `lang_OBJS` may cause the unwilling issue, say, you can't run `make -j n` otherwise the compiler complains `insn_modes.h` is missing. Now we can use `make -j n`.

BTW, could you authorize me to push the branch directly? That's better than maintaining forks. And you can protect the master branch. 
