### PR TITLE
Phil/compilation simple

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -70,6 +70,7 @@ GRS_OBJS = \
     rust/rust-ast-full-test.o \
     rust/rust-session-manager.o \
     rust/rust-resolution.o \
+    rust/rust-scan.o \
     rust/rust-compile.o \
     $(END)
 # removed object files from here 

--- a/gcc/rust/analysis/rust-resolution.cc
+++ b/gcc/rust/analysis/rust-resolution.cc
@@ -727,8 +727,7 @@ TypeResolution::visit (AST::LetStmt &stmt)
   // ensure the decl has the type set for compilation later on
   if (!stmt.has_type ())
     {
-      // FIXME
-      // stmt.type = inferedType;
+      stmt.inferedType = inferedType;
     }
 
   // get all the names part of this declaration and add the types to the scope

--- a/gcc/rust/analysis/rust-resolution.cc
+++ b/gcc/rust/analysis/rust-resolution.cc
@@ -19,7 +19,8 @@
 namespace Rust {
 namespace Analysis {
 
-TypeResolution::TypeResolution (AST::Crate &crate) : crate (crate)
+TypeResolution::TypeResolution (AST::Crate &crate, TopLevelScan &toplevel)
+  : crate (crate), toplevel (toplevel)
 {
   typeScope.Push ();
   scope.Push ();
@@ -50,9 +51,9 @@ TypeResolution::~TypeResolution ()
 }
 
 bool
-TypeResolution::ResolveNamesAndTypes (AST::Crate &crate)
+TypeResolution::ResolveNamesAndTypes (AST::Crate &crate, TopLevelScan &toplevel)
 {
-  TypeResolution resolver (crate);
+  TypeResolution resolver (crate, toplevel);
   return resolver.go ();
 }
 
@@ -315,7 +316,11 @@ TypeResolution::visit (AST::AssignmentExpr &expr)
   // scope will require knowledge of the type
 
   // do the lhsType and the rhsType match
-  typesAreCompatible (lhsType, rhsType, expr.right_expr->get_locus_slow ());
+  if (!typesAreCompatible (lhsType, rhsType,
+			   expr.right_expr->get_locus_slow ()))
+    return;
+
+  // is the lhs mutable?
 }
 
 void

--- a/gcc/rust/analysis/rust-resolution.cc
+++ b/gcc/rust/analysis/rust-resolution.cc
@@ -254,9 +254,7 @@ TypeResolution::visit (AST::ComparisonExpr &expr)
 
 void
 TypeResolution::visit (AST::LazyBooleanExpr &expr)
-{
-  printf ("LazyBooleanExpr: %s\n", expr.as_string ().c_str ());
-}
+{}
 
 void
 TypeResolution::visit (AST::TypeCastExpr &expr)
@@ -270,9 +268,7 @@ TypeResolution::visit (AST::AssignmentExpr &expr)
 
 void
 TypeResolution::visit (AST::CompoundAssignmentExpr &expr)
-{
-  printf ("CompoundAssignmentExpr: %s\n", expr.as_string ().c_str ());
-}
+{}
 
 void
 TypeResolution::visit (AST::GroupedExpr &expr)
@@ -340,9 +336,13 @@ TypeResolution::visit (AST::EnumExprTuple &expr)
 void
 TypeResolution::visit (AST::EnumExprFieldless &expr)
 {}
+
 void
 TypeResolution::visit (AST::CallExpr &expr)
-{}
+{
+  printf ("CallExpr: %s\n", expr.as_string ().c_str ());
+}
+
 void
 TypeResolution::visit (AST::MethodCallExpr &expr)
 {}
@@ -481,18 +481,25 @@ TypeResolution::visit (AST::UseDeclaration &use_decl)
 void
 TypeResolution::visit (AST::Function &function)
 {
+  // always emit the function with return type in the event of nil return type
+  // its  a marker for a void function
   scope.Insert (function.function_name, function.return_type.get ());
 
   scope.Push ();
-  printf ("INSIDE FUNCTION: %s\n", function.function_name.c_str ());
-
   for (auto &param : function.function_params)
     {
-      printf ("FUNC PARAM: %s\n", param.as_string ().c_str ());
-    }
+      auto before = letPatternBuffer.size ();
+      param.param_name->accept_vis (*this);
+      if (letPatternBuffer.size () <= before)
+	{
+	  rust_error_at (param.locus, "failed to analyse parameter name");
+	  return;
+	}
 
-  // ensure return types
-  // TODO
+      auto paramName = letPatternBuffer.back ();
+      letPatternBuffer.pop_back ();
+      scope.Insert (paramName.variable_ident, param.type.get ());
+    }
 
   // walk the expression body
   for (auto &stmt : function.function_body->statements)
@@ -742,16 +749,12 @@ TypeResolution::visit (AST::LetStmt &stmt)
 void
 TypeResolution::visit (AST::ExprStmtWithoutBlock &stmt)
 {
-  printf ("ExprStmtWithoutBlock: %s\n", stmt.as_string ().c_str ());
   stmt.expr->accept_vis (*this);
 }
 
 void
 TypeResolution::visit (AST::ExprStmtWithBlock &stmt)
-{
-  printf ("ExprStmtWithBlock: %s\n", stmt.as_string ().c_str ());
-  stmt.expr->accept_vis (*this);
-}
+{}
 
 // rust-type.h
 void

--- a/gcc/rust/analysis/rust-resolution.cc
+++ b/gcc/rust/analysis/rust-resolution.cc
@@ -263,7 +263,32 @@ TypeResolution::visit (AST::TypeCastExpr &expr)
 void
 TypeResolution::visit (AST::AssignmentExpr &expr)
 {
-  printf ("AssignmentExpr: %s\n", expr.as_string ().c_str ());
+  size_t before;
+  before = typeBuffer.size ();
+  expr.visit_lhs (*this);
+  if (typeBuffer.size () <= before)
+    {
+      rust_error_at (expr.locus, "unable to determine lhs type");
+      return;
+    }
+
+  auto lhsType = typeBuffer.back ();
+  typeBuffer.pop_back ();
+
+  before = typeBuffer.size ();
+  expr.visit_rhs (*this);
+  if (typeBuffer.size () <= before)
+    {
+      rust_error_at (expr.locus, "unable to determine rhs type");
+      return;
+    }
+
+  auto rhsType = typeBuffer.back ();
+  // not poping because we will be checking they match and the
+  // scope will require knowledge of the type
+
+  // do the lhsType and the rhsType match
+  // TODO
 }
 
 void

--- a/gcc/rust/analysis/rust-resolution.h
+++ b/gcc/rust/analysis/rust-resolution.h
@@ -225,12 +225,15 @@ private:
 
   bool go ();
 
+  bool typesAreCompatible (std::string &lhs, std::string &rhs) const;
+
   Scope<AST::Type *> scope;
   Scope<AST::Type *> typeScope;
   AST::Crate &crate;
 
   std::vector<AST::IdentifierPattern> letPatternBuffer;
   std::vector<AST::Type *> typeBuffer;
+  std::vector<std::string> typeComparisonBuffer;
 };
 
 } // namespace Analysis

--- a/gcc/rust/analysis/rust-resolution.h
+++ b/gcc/rust/analysis/rust-resolution.h
@@ -225,7 +225,7 @@ private:
 
   bool go ();
 
-  bool typesAreCompatible (std::string &lhs, std::string &rhs) const;
+  bool typesAreCompatible (AST::Type *lhs, AST::Type *rhs, Location locus);
 
   Scope<AST::Type *> scope;
   Scope<AST::Type *> typeScope;

--- a/gcc/rust/analysis/rust-resolution.h
+++ b/gcc/rust/analysis/rust-resolution.h
@@ -225,8 +225,8 @@ private:
 
   bool go ();
 
-  Scope scope;
-  Scope typeScope;
+  Scope<AST::Type *> scope;
+  Scope<AST::Type *> typeScope;
   AST::Crate &crate;
 
   std::vector<AST::IdentifierPattern> letPatternBuffer;

--- a/gcc/rust/analysis/rust-scan.cc
+++ b/gcc/rust/analysis/rust-scan.cc
@@ -1,0 +1,571 @@
+#include "rust-scan.h"
+#include "rust-diagnostics.h"
+
+namespace Rust {
+namespace Analysis {
+
+TopLevelScan::TopLevelScan (AST::Crate &crate) : crate (crate)
+{
+  for (auto &item : crate.items)
+    item->accept_vis (*this);
+}
+
+TopLevelScan::~TopLevelScan () {}
+
+void
+TopLevelScan::visit (AST::Token &tok)
+{}
+
+void
+TopLevelScan::visit (AST::DelimTokenTree &delim_tok_tree)
+{}
+
+void
+TopLevelScan::visit (AST::AttrInputMetaItemContainer &input)
+{}
+
+void
+TopLevelScan::visit (AST::IdentifierExpr &ident_expr)
+{}
+
+void
+TopLevelScan::visit (AST::Lifetime &lifetime)
+{}
+
+void
+TopLevelScan::visit (AST::LifetimeParam &lifetime_param)
+{}
+
+void
+TopLevelScan::visit (AST::MacroInvocationSemi &macro)
+{}
+
+// rust-path.h
+void
+TopLevelScan::visit (AST::PathInExpression &path)
+{}
+
+void
+TopLevelScan::visit (AST::TypePathSegment &segment)
+{}
+void
+TopLevelScan::visit (AST::TypePathSegmentGeneric &segment)
+{}
+
+void
+TopLevelScan::visit (AST::TypePathSegmentFunction &segment)
+{}
+
+void
+TopLevelScan::visit (AST::TypePath &path)
+{}
+
+void
+TopLevelScan::visit (AST::QualifiedPathInExpression &path)
+{}
+
+void
+TopLevelScan::visit (AST::QualifiedPathInType &path)
+{}
+
+// rust-expr.h
+void
+TopLevelScan::visit (AST::LiteralExpr &expr)
+{}
+
+void
+TopLevelScan::visit (AST::AttrInputLiteral &attr_input)
+{}
+
+void
+TopLevelScan::visit (AST::MetaItemLitExpr &meta_item)
+{}
+
+void
+TopLevelScan::visit (AST::MetaItemPathLit &meta_item)
+{}
+
+void
+TopLevelScan::visit (AST::BorrowExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::DereferenceExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::ErrorPropagationExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::NegationExpr &expr)
+{}
+
+void
+TopLevelScan::visit (AST::ArithmeticOrLogicalExpr &expr)
+{}
+
+void
+TopLevelScan::visit (AST::ComparisonExpr &expr)
+{}
+
+void
+TopLevelScan::visit (AST::LazyBooleanExpr &expr)
+{}
+
+void
+TopLevelScan::visit (AST::TypeCastExpr &expr)
+{}
+
+void
+TopLevelScan::visit (AST::AssignmentExpr &expr)
+{}
+
+void
+TopLevelScan::visit (AST::CompoundAssignmentExpr &expr)
+{}
+
+void
+TopLevelScan::visit (AST::GroupedExpr &expr)
+{}
+// void TopLevelScan::visit(ArrayElems& elems) {}
+void
+TopLevelScan::visit (AST::ArrayElemsValues &elems)
+{}
+void
+TopLevelScan::visit (AST::ArrayElemsCopied &elems)
+{}
+void
+TopLevelScan::visit (AST::ArrayExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::ArrayIndexExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::TupleExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::TupleIndexExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::StructExprStruct &expr)
+{}
+// void TopLevelScan::visit(StructExprField& field) {}
+void
+TopLevelScan::visit (AST::StructExprFieldIdentifier &field)
+{}
+void
+TopLevelScan::visit (AST::StructExprFieldIdentifierValue &field)
+{}
+void
+TopLevelScan::visit (AST::StructExprFieldIndexValue &field)
+{}
+void
+TopLevelScan::visit (AST::StructExprStructFields &expr)
+{}
+void
+TopLevelScan::visit (AST::StructExprStructBase &expr)
+{}
+void
+TopLevelScan::visit (AST::StructExprTuple &expr)
+{}
+void
+TopLevelScan::visit (AST::StructExprUnit &expr)
+{}
+// void TopLevelScan::visit(EnumExprField& field) {}
+void
+TopLevelScan::visit (AST::EnumExprFieldIdentifier &field)
+{}
+void
+TopLevelScan::visit (AST::EnumExprFieldIdentifierValue &field)
+{}
+void
+TopLevelScan::visit (AST::EnumExprFieldIndexValue &field)
+{}
+void
+TopLevelScan::visit (AST::EnumExprStruct &expr)
+{}
+void
+TopLevelScan::visit (AST::EnumExprTuple &expr)
+{}
+void
+TopLevelScan::visit (AST::EnumExprFieldless &expr)
+{}
+
+void
+TopLevelScan::visit (AST::CallExpr &expr)
+{}
+
+void
+TopLevelScan::visit (AST::MethodCallExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::FieldAccessExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::ClosureExprInner &expr)
+{}
+void
+TopLevelScan::visit (AST::BlockExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::ClosureExprInnerTyped &expr)
+{}
+void
+TopLevelScan::visit (AST::ContinueExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::BreakExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::RangeFromToExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::RangeFromExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::RangeToExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::RangeFullExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::RangeFromToInclExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::RangeToInclExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::ReturnExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::UnsafeBlockExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::LoopExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::WhileLoopExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::WhileLetLoopExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::ForLoopExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::IfExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::IfExprConseqElse &expr)
+{}
+void
+TopLevelScan::visit (AST::IfExprConseqIf &expr)
+{}
+void
+TopLevelScan::visit (AST::IfExprConseqIfLet &expr)
+{}
+void
+TopLevelScan::visit (AST::IfLetExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::IfLetExprConseqElse &expr)
+{}
+void
+TopLevelScan::visit (AST::IfLetExprConseqIf &expr)
+{}
+void
+TopLevelScan::visit (AST::IfLetExprConseqIfLet &expr)
+{}
+// void TopLevelScan::visit(MatchCase& match_case) {}
+void
+TopLevelScan::visit (AST::MatchCaseBlockExpr &match_case)
+{}
+void
+TopLevelScan::visit (AST::MatchCaseExpr &match_case)
+{}
+void
+TopLevelScan::visit (AST::MatchExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::AwaitExpr &expr)
+{}
+void
+TopLevelScan::visit (AST::AsyncBlockExpr &expr)
+{}
+
+// rust-item.h
+void
+TopLevelScan::visit (AST::TypeParam &param)
+{}
+// void TopLevelScan::visit(WhereClauseItem& item) {}
+void
+TopLevelScan::visit (AST::LifetimeWhereClauseItem &item)
+{}
+void
+TopLevelScan::visit (AST::TypeBoundWhereClauseItem &item)
+{}
+void
+TopLevelScan::visit (AST::Method &method)
+{}
+void
+TopLevelScan::visit (AST::ModuleBodied &module)
+{}
+void
+TopLevelScan::visit (AST::ModuleNoBody &module)
+{}
+void
+TopLevelScan::visit (AST::ExternCrate &crate)
+{}
+// void TopLevelScan::visit(UseTree& use_tree) {}
+void
+TopLevelScan::visit (AST::UseTreeGlob &use_tree)
+{}
+void
+TopLevelScan::visit (AST::UseTreeList &use_tree)
+{}
+void
+TopLevelScan::visit (AST::UseTreeRebind &use_tree)
+{}
+void
+TopLevelScan::visit (AST::UseDeclaration &use_decl)
+{}
+
+void
+TopLevelScan::visit (AST::Function &function)
+{
+  functions[function.function_name] = &function;
+}
+
+void
+TopLevelScan::visit (AST::TypeAlias &type_alias)
+{}
+void
+TopLevelScan::visit (AST::StructStruct &struct_item)
+{}
+void
+TopLevelScan::visit (AST::TupleStruct &tuple_struct)
+{}
+void
+TopLevelScan::visit (AST::EnumItem &item)
+{}
+void
+TopLevelScan::visit (AST::EnumItemTuple &item)
+{}
+void
+TopLevelScan::visit (AST::EnumItemStruct &item)
+{}
+void
+TopLevelScan::visit (AST::EnumItemDiscriminant &item)
+{}
+void
+TopLevelScan::visit (AST::Enum &enum_item)
+{}
+void
+TopLevelScan::visit (AST::Union &union_item)
+{}
+
+void
+TopLevelScan::visit (AST::ConstantItem &const_item)
+{}
+
+void
+TopLevelScan::visit (AST::StaticItem &static_item)
+{}
+void
+TopLevelScan::visit (AST::TraitItemFunc &item)
+{}
+void
+TopLevelScan::visit (AST::TraitItemMethod &item)
+{}
+void
+TopLevelScan::visit (AST::TraitItemConst &item)
+{}
+void
+TopLevelScan::visit (AST::TraitItemType &item)
+{}
+void
+TopLevelScan::visit (AST::Trait &trait)
+{}
+void
+TopLevelScan::visit (AST::InherentImpl &impl)
+{}
+void
+TopLevelScan::visit (AST::TraitImpl &impl)
+{}
+// void TopLevelScan::visit(ExternalItem& item) {}
+void
+TopLevelScan::visit (AST::ExternalStaticItem &item)
+{}
+void
+TopLevelScan::visit (AST::ExternalFunctionItem &item)
+{}
+void
+TopLevelScan::visit (AST::ExternBlock &block)
+{}
+
+// rust-macro.h
+void
+TopLevelScan::visit (AST::MacroMatchFragment &match)
+{}
+void
+TopLevelScan::visit (AST::MacroMatchRepetition &match)
+{}
+void
+TopLevelScan::visit (AST::MacroMatcher &matcher)
+{}
+void
+TopLevelScan::visit (AST::MacroRulesDefinition &rules_def)
+{}
+void
+TopLevelScan::visit (AST::MacroInvocation &macro_invoc)
+{}
+void
+TopLevelScan::visit (AST::MetaItemPath &meta_item)
+{}
+void
+TopLevelScan::visit (AST::MetaItemSeq &meta_item)
+{}
+void
+TopLevelScan::visit (AST::MetaWord &meta_item)
+{}
+void
+TopLevelScan::visit (AST::MetaNameValueStr &meta_item)
+{}
+void
+TopLevelScan::visit (AST::MetaListPaths &meta_item)
+{}
+void
+TopLevelScan::visit (AST::MetaListNameValueStr &meta_item)
+{}
+
+// rust-pattern.h
+void
+TopLevelScan::visit (AST::LiteralPattern &pattern)
+{}
+
+void
+TopLevelScan::visit (AST::IdentifierPattern &pattern)
+{}
+
+void
+TopLevelScan::visit (AST::WildcardPattern &pattern)
+{}
+// void TopLevelScan::visit(RangePatternBound& bound) {}
+void
+TopLevelScan::visit (AST::RangePatternBoundLiteral &bound)
+{}
+void
+TopLevelScan::visit (AST::RangePatternBoundPath &bound)
+{}
+void
+TopLevelScan::visit (AST::RangePatternBoundQualPath &bound)
+{}
+void
+TopLevelScan::visit (AST::RangePattern &pattern)
+{}
+void
+TopLevelScan::visit (AST::ReferencePattern &pattern)
+{}
+// void TopLevelScan::visit(StructPatternField& field) {}
+void
+TopLevelScan::visit (AST::StructPatternFieldTuplePat &field)
+{}
+void
+TopLevelScan::visit (AST::StructPatternFieldIdentPat &field)
+{}
+void
+TopLevelScan::visit (AST::StructPatternFieldIdent &field)
+{}
+void
+TopLevelScan::visit (AST::StructPattern &pattern)
+{}
+// void TopLevelScan::visit(TupleStructItems& tuple_items) {}
+void
+TopLevelScan::visit (AST::TupleStructItemsNoRange &tuple_items)
+{}
+void
+TopLevelScan::visit (AST::TupleStructItemsRange &tuple_items)
+{}
+void
+TopLevelScan::visit (AST::TupleStructPattern &pattern)
+{}
+// void TopLevelScan::visit(TuplePatternItems& tuple_items) {}
+void
+TopLevelScan::visit (AST::TuplePatternItemsMultiple &tuple_items)
+{}
+void
+TopLevelScan::visit (AST::TuplePatternItemsRanged &tuple_items)
+{}
+void
+TopLevelScan::visit (AST::TuplePattern &pattern)
+{}
+void
+TopLevelScan::visit (AST::GroupedPattern &pattern)
+{}
+void
+TopLevelScan::visit (AST::SlicePattern &pattern)
+{}
+
+// rust-stmt.h
+void
+TopLevelScan::visit (AST::EmptyStmt &stmt)
+{}
+
+void
+TopLevelScan::visit (AST::LetStmt &stmt)
+{}
+
+void
+TopLevelScan::visit (AST::ExprStmtWithoutBlock &stmt)
+{}
+
+void
+TopLevelScan::visit (AST::ExprStmtWithBlock &stmt)
+{}
+
+// rust-type.h
+void
+TopLevelScan::visit (AST::TraitBound &bound)
+{}
+
+void
+TopLevelScan::visit (AST::ImplTraitType &type)
+{}
+
+void
+TopLevelScan::visit (AST::TraitObjectType &type)
+{}
+void
+TopLevelScan::visit (AST::ParenthesisedType &type)
+{}
+void
+TopLevelScan::visit (AST::ImplTraitTypeOneBound &type)
+{}
+void
+TopLevelScan::visit (AST::TraitObjectTypeOneBound &type)
+{}
+void
+TopLevelScan::visit (AST::TupleType &type)
+{}
+void
+TopLevelScan::visit (AST::NeverType &type)
+{}
+void
+TopLevelScan::visit (AST::RawPointerType &type)
+{}
+void
+TopLevelScan::visit (AST::ReferenceType &type)
+{}
+void
+TopLevelScan::visit (AST::ArrayType &type)
+{}
+void
+TopLevelScan::visit (AST::SliceType &type)
+{}
+void
+TopLevelScan::visit (AST::InferredType &type)
+{}
+void
+TopLevelScan::visit (AST::BareFunctionType &type)
+{}
+
+} // namespace Analysis
+} // namespace Rust

--- a/gcc/rust/analysis/rust-scan.h
+++ b/gcc/rust/analysis/rust-scan.h
@@ -3,18 +3,17 @@
 #include "rust-system.h"
 #include "rust-ast-full.h"
 #include "rust-ast-visitor.h"
-#include "rust-scan.h"
 #include "scope.h"
 
 namespace Rust {
 namespace Analysis {
 
-class TypeResolution : public AST::ASTVisitor
+class TopLevelScan : public AST::ASTVisitor
 {
 public:
-  static bool ResolveNamesAndTypes (AST::Crate &crate, TopLevelScan &toplevel);
+  TopLevelScan (AST::Crate &crate);
 
-  ~TypeResolution ();
+  ~TopLevelScan ();
 
   // visitor impl
   // rust-ast.h
@@ -222,20 +221,8 @@ public:
   virtual void visit (AST::BareFunctionType &type);
 
 private:
-  TypeResolution (AST::Crate &crate, TopLevelScan &toplevel);
-
-  bool go ();
-
-  bool typesAreCompatible (AST::Type *lhs, AST::Type *rhs, Location locus);
-
-  Scope<AST::Type *> scope;
-  Scope<AST::Type *> typeScope;
+  std::map<std::string, AST::Function *> functions;
   AST::Crate &crate;
-  TopLevelScan &toplevel;
-
-  std::vector<AST::IdentifierPattern> letPatternBuffer;
-  std::vector<AST::Type *> typeBuffer;
-  std::vector<std::string> typeComparisonBuffer;
 };
 
 } // namespace Analysis

--- a/gcc/rust/analysis/scope.h
+++ b/gcc/rust/analysis/scope.h
@@ -6,14 +6,14 @@
 namespace Rust {
 namespace Analysis {
 
-class Scope
+template <class T> class Scope
 {
 public:
   Scope () : scopeStack () {}
 
   ~Scope () {}
 
-  bool Insert (std::string key, AST::Type *val)
+  bool Insert (std::string key, T val)
   {
     if (scopeStack.back ().find (key) != scopeStack.back ().end ())
       {
@@ -24,7 +24,7 @@ public:
     return true;
   }
 
-  bool Lookup (std::string key, AST::Type **result)
+  bool Lookup (std::string key, T *result)
   {
     for (auto it = scopeStack.rbegin (); it != scopeStack.rend (); ++it)
       {
@@ -40,7 +40,7 @@ public:
 
   void Push () { scopeStack.push_back ({}); }
 
-  std ::map<std::string, AST::Type *> Pop ()
+  std ::map<std::string, T> Pop ()
   {
     auto toplevel = scopeStack.back ();
     scopeStack.pop_back ();
@@ -48,7 +48,7 @@ public:
   }
 
 private:
-  std::vector<std::map<std::string, AST::Type *> > scopeStack;
+  std::vector<std::map<std::string, T> > scopeStack;
 };
 
 } // namespace Analysis

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -2527,6 +2527,7 @@ protected:
 // Function call expression AST node
 class CallExpr : public ExprWithoutBlock
 {
+public:
   // Expr* function;
   ::std::unique_ptr<Expr> function;
   //::std::vector<Expr> params; // inlined form of CallParams
@@ -2534,7 +2535,6 @@ class CallExpr : public ExprWithoutBlock
 
   Location locus;
 
-public:
   /*~CallExpr() {
       delete function;
   }*/

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -568,7 +568,6 @@ public:
     RIGHT_SHIFT	 // std::ops::Shr
   };
 
-private:
   // Note: overloading trait specified in comments
   ExprType expr_type;
 
@@ -880,10 +879,10 @@ protected:
 // Binary assignment expression.
 class AssignmentExpr : public OperatorExpr
 {
+public:
   // Expr* right_expr;
   ::std::unique_ptr<Expr> right_expr;
 
-public:
   /*~AssignmentExpr() {
       delete right_expr;
   }*/

--- a/gcc/rust/ast/rust-expr.h
+++ b/gcc/rust/ast/rust-expr.h
@@ -941,6 +941,10 @@ public:
 
   virtual void accept_vis (ASTVisitor &vis) OVERRIDE;
 
+  void visit_lhs (ASTVisitor &vis) { main_or_left_expr->accept_vis (vis); }
+
+  void visit_rhs (ASTVisitor &vis) { right_expr->accept_vis (vis); }
+
 protected:
   // Use covariance to implement clone function as returning this object rather
   // than base

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -496,7 +496,7 @@ public:
 // A function parameter
 struct FunctionParam
 {
-private:
+public:
   // Pattern* param_name;
   ::std::unique_ptr<Pattern> param_name;
   // Type type;
@@ -504,7 +504,6 @@ private:
 
   Location locus;
 
-public:
   FunctionParam (::std::unique_ptr<Pattern> param_name,
 		 ::std::unique_ptr<Type> param_type, Location locus)
     : param_name (::std::move (param_name)), type (::std::move (param_type)),

--- a/gcc/rust/ast/rust-stmt.h
+++ b/gcc/rust/ast/rust-stmt.h
@@ -63,6 +63,8 @@ public:
 
   Location locus;
 
+  Type *inferedType;
+
   // Returns whether let statement has outer attributes.
   inline bool has_outer_attrs () const { return !outer_attrs.empty (); }
 

--- a/gcc/rust/backend/rust-compile.cc
+++ b/gcc/rust/backend/rust-compile.cc
@@ -361,7 +361,6 @@ Compilation::visit (AST::Function &function)
       printf ("FUNC PARAM: %s\n", param.as_string ().c_str ());
       // TODO
     }
-
   if (parameters.size () != function.function_params.size ())
     {
       rust_error_at (function.locus,

--- a/gcc/rust/backend/rust-compile.h
+++ b/gcc/rust/backend/rust-compile.h
@@ -226,7 +226,7 @@ private:
 
   bool go ();
 
-  Analysis::Scope scope;
+  Analysis::Scope<AST::Type *> scope;
   AST::Crate &crate;
   Backend *backend;
 

--- a/gcc/rust/rust-session-manager.cc
+++ b/gcc/rust/rust-session-manager.cc
@@ -5,6 +5,7 @@
 
 #include "rust-lex.h"
 #include "rust-parse.h"
+#include "rust-scan.h"
 #include "rust-resolution.h"
 #include "rust-compile.h"
 
@@ -700,7 +701,8 @@ void
 Session::name_resolution (AST::Crate &crate)
 {
   fprintf (stderr, "started name resolution\n");
-  Analysis::TypeResolution::ResolveNamesAndTypes (crate);
+  Analysis::TopLevelScan toplevel (crate);
+  Analysis::TypeResolution::ResolveNamesAndTypes (crate, toplevel);
   fprintf (stderr, "finished name resolution\n");
 }
 


### PR DESCRIPTION
This adds in initial support for type checking:

```
started name resolution
test1.rs:21:15: error: E0308: expected: i32, found bool
   21 |     mutable = true;
      |               ^
finished name resolution
```