### PR TITLE
Phil/compilation simple

### DIFF
--- a/gcc/rust/analysis/rust-type-resolution.cc
+++ b/gcc/rust/analysis/rust-type-resolution.cc
@@ -700,9 +700,24 @@ TypeResolution::visit (AST::Function &function)
 void
 TypeResolution::visit (AST::TypeAlias &type_alias)
 {}
+
 void
 TypeResolution::visit (AST::StructStruct &struct_item)
-{}
+{
+  for (auto &field : struct_item.fields)
+    {
+      if (!isTypeInScope (field.field_type.get (),
+			  Linemap::unknown_location ()))
+	{
+	  rust_fatal_error (Linemap::unknown_location (),
+			    "unknown type in struct field");
+	  return;
+	}
+    }
+
+  structsPerBlock.Insert (struct_item.struct_name, &struct_item);
+}
+
 void
 TypeResolution::visit (AST::TupleStruct &tuple_struct)
 {}

--- a/gcc/rust/analysis/rust-type-resolution.cc
+++ b/gcc/rust/analysis/rust-type-resolution.cc
@@ -12,7 +12,7 @@
       segs.push_back (::std::move (typePath));                                 \
       auto bType = new AST::TypePath (::std::move (segs),                      \
 				      Linemap::unknown_location (), false);    \
-      _S.Insert (_X, bType);                                                   \
+      _S.InsertType (_X, bType);                                               \
     }                                                                          \
   while (0)
 
@@ -22,32 +22,34 @@ namespace Analysis {
 TypeResolution::TypeResolution (AST::Crate &crate, TopLevelScan &toplevel)
   : Resolution (crate, toplevel)
 {
-  functionScope.Push ();
-  localsPerBlock.Push ();
+  scope.Push ();
 
   // push all builtin types - this is probably too basic for future needs
-  ADD_BUILTIN_TYPE ("u8", typeScope);
-  ADD_BUILTIN_TYPE ("u16", typeScope);
-  ADD_BUILTIN_TYPE ("u32", typeScope);
-  ADD_BUILTIN_TYPE ("u64", typeScope);
+  ADD_BUILTIN_TYPE ("u8", scope);
+  ADD_BUILTIN_TYPE ("u16", scope);
+  ADD_BUILTIN_TYPE ("u32", scope);
+  ADD_BUILTIN_TYPE ("u64", scope);
 
-  ADD_BUILTIN_TYPE ("i8", typeScope);
-  ADD_BUILTIN_TYPE ("i16", typeScope);
-  ADD_BUILTIN_TYPE ("i32", typeScope);
-  ADD_BUILTIN_TYPE ("i64", typeScope);
+  ADD_BUILTIN_TYPE ("i8", scope);
+  ADD_BUILTIN_TYPE ("i16", scope);
+  ADD_BUILTIN_TYPE ("i32", scope);
+  ADD_BUILTIN_TYPE ("i64", scope);
 
-  ADD_BUILTIN_TYPE ("f32", typeScope);
-  ADD_BUILTIN_TYPE ("f64", typeScope);
+  ADD_BUILTIN_TYPE ("f32", scope);
+  ADD_BUILTIN_TYPE ("f64", scope);
 
-  ADD_BUILTIN_TYPE ("char", typeScope);
-  ADD_BUILTIN_TYPE ("str", typeScope);
-  ADD_BUILTIN_TYPE ("bool", typeScope);
+  ADD_BUILTIN_TYPE ("char", scope);
+  ADD_BUILTIN_TYPE ("str", scope);
+  ADD_BUILTIN_TYPE ("bool", scope);
+
+  // now its the crate scope
+  scope.Push ();
 }
 
 TypeResolution::~TypeResolution ()
 {
-  functionScope.Pop ();
-  localsPerBlock.Pop ();
+  scope.Pop (); // crate
+  scope.Pop (); // builtins
 }
 
 bool
@@ -101,13 +103,7 @@ TypeResolution::typesAreCompatible (AST::Type *lhs, AST::Type *rhs,
     }
 
   AST::Type *val = NULL;
-  if (!typeScope.Lookup (lhsTypeStr, &val))
-    {
-      rust_error_at (locus, "unknown type");
-      return false;
-    }
-
-  return true;
+  return scope.LookupType (lhsTypeStr, &val);
 }
 
 bool
@@ -126,13 +122,7 @@ TypeResolution::isTypeInScope (AST::Type *type, Location locus)
   typeComparisonBuffer.pop_back ();
 
   AST::Type *val = NULL;
-  if (!typeScope.Lookup (t, &val))
-    {
-      rust_error_at (locus, "unknown type");
-      return false;
-    }
-
-  return true;
+  return scope.LookupType (t, &val);
 }
 
 AST::Function *
@@ -167,7 +157,7 @@ void
 TypeResolution::visit (AST::IdentifierExpr &ident_expr)
 {
   AST::Type *type = NULL;
-  bool ok = scope.Lookup (ident_expr.ident, &type);
+  bool ok = scope.LookupType (ident_expr.ident, &type);
   if (!ok)
     {
       rust_error_at (ident_expr.locus, "unknown identifier");
@@ -195,7 +185,7 @@ TypeResolution::visit (AST::PathInExpression &path)
 {
   // look up in the functionScope else lookup in the toplevel scan
   AST::Function *fndecl = NULL;
-  if (functionScope.Lookup (path.as_string (), &fndecl))
+  if (scope.LookupFunction (path.as_string (), &fndecl))
     {
       functionLookup.push_back (fndecl);
       return;
@@ -287,7 +277,7 @@ TypeResolution::visit (AST::LiteralExpr &expr)
     }
 
   AST::Type *val = NULL;
-  bool ok = typeScope.Lookup (type, &val);
+  bool ok = scope.LookupType (type, &val);
   if (ok)
     typeBuffer.push_back (val);
   else
@@ -521,9 +511,18 @@ TypeResolution::visit (AST::FieldAccessExpr &expr)
 void
 TypeResolution::visit (AST::ClosureExprInner &expr)
 {}
+
 void
 TypeResolution::visit (AST::BlockExpr &expr)
-{}
+{
+  scope.Push ();
+  for (auto &stmt : expr.statements)
+    {
+      stmt->accept_vis (*this);
+    }
+  scope.Pop ();
+}
+
 void
 TypeResolution::visit (AST::ClosureExprInnerTyped &expr)
 {}
@@ -569,15 +568,27 @@ TypeResolution::visit (AST::WhileLetLoopExpr &expr)
 void
 TypeResolution::visit (AST::ForLoopExpr &expr)
 {}
+
 void
 TypeResolution::visit (AST::IfExpr &expr)
-{}
+{
+  expr.vis_if_block (*this);
+}
+
 void
 TypeResolution::visit (AST::IfExprConseqElse &expr)
-{}
+{
+  expr.vis_if_block (*this);
+  expr.vis_else_block (*this);
+}
+
 void
 TypeResolution::visit (AST::IfExprConseqIf &expr)
-{}
+{
+  expr.vis_if_block (*this);
+  expr.vis_conseq_if_expr (*this);
+}
+
 void
 TypeResolution::visit (AST::IfExprConseqIfLet &expr)
 {}
@@ -652,11 +663,10 @@ TypeResolution::visit (AST::Function &function)
 {
   // always emit the function with return type in the event of nil return type
   // its  a marker for a void function
-  scope.Insert (function.function_name, function.return_type.get ());
-  functionScope.Insert (function.function_name, &function);
-
-  functionScope.Push ();
+  scope.InsertType (function.function_name, function.return_type.get ());
+  scope.InsertFunction (function.function_name, &function);
   scope.Push ();
+
   for (auto &param : function.function_params)
     {
       if (!isTypeInScope (param.type.get (), param.locus))
@@ -672,7 +682,7 @@ TypeResolution::visit (AST::Function &function)
 
       auto paramName = letPatternBuffer.back ();
       letPatternBuffer.pop_back ();
-      scope.Insert (paramName.variable_ident, param.type.get ());
+      scope.InsertType (paramName.variable_ident, param.type.get ());
     }
 
   // ensure the return type is resolved
@@ -683,18 +693,16 @@ TypeResolution::visit (AST::Function &function)
     }
 
   // walk the expression body
-  localsPerBlock.Push ();
   for (auto &stmt : function.function_body->statements)
     {
       stmt->accept_vis (*this);
     }
 
-  auto localMap = localsPerBlock.Pop ();
+  auto localMap = scope.PeekLocals ();
   for (auto &[_, value] : localMap)
     function.locals.push_back (value);
 
   scope.Pop ();
-  functionScope.Pop ();
 }
 
 void
@@ -715,7 +723,7 @@ TypeResolution::visit (AST::StructStruct &struct_item)
 	}
     }
 
-  structsPerBlock.Insert (struct_item.struct_name, &struct_item);
+  scope.InsertStruct (struct_item.struct_name, &struct_item);
 }
 
 void
@@ -896,8 +904,7 @@ TypeResolution::visit (AST::EmptyStmt &stmt)
 void
 TypeResolution::visit (AST::LetStmt &stmt)
 {
-  localsPerBlock.Insert (stmt.as_string (), &stmt);
-
+  scope.InsertLocal (stmt.as_string (), &stmt);
   if (!stmt.has_init_expr () && !stmt.has_type ())
     {
       rust_error_at (stmt.locus,
@@ -948,7 +955,7 @@ TypeResolution::visit (AST::LetStmt &stmt)
   // get all the names part of this declaration and add the types to the scope
   stmt.variables_pattern->accept_vis (*this);
   for (auto &pattern : letPatternBuffer)
-    scope.Insert (pattern.variable_ident, inferedType);
+    scope.InsertType (pattern.variable_ident, inferedType);
 
   letPatternBuffer.clear ();
 }
@@ -962,11 +969,14 @@ TypeResolution::visit (AST::ExprStmtWithoutBlock &stmt)
 void
 TypeResolution::visit (AST::ExprStmtWithBlock &stmt)
 {
-  localsPerBlock.Push ();
+  scope.Push ();
   stmt.expr->accept_vis (*this);
-  auto localMap = localsPerBlock.Pop ();
+  auto localMap = scope.PeekLocals ();
   for (auto &[_, value] : localMap)
-    stmt.locals.push_back (value);
+    {
+      stmt.locals.push_back (value);
+    }
+  scope.Pop ();
 }
 
 // rust-type.h

--- a/gcc/rust/analysis/rust-type-resolution.h
+++ b/gcc/rust/analysis/rust-type-resolution.h
@@ -5,8 +5,85 @@
 namespace Rust {
 namespace Analysis {
 
+class TypeScoping
+{
+public:
+  TypeScoping () {}
+
+  ~TypeScoping () {}
+
+  void Push ()
+  {
+    functionScope.Push ();
+    localsPerBlock.Push ();
+    structsPerBlock.Push ();
+    typeScope.Push ();
+  }
+
+  void Pop ()
+  {
+    functionScope.Pop ();
+    localsPerBlock.Pop ();
+    structsPerBlock.Pop ();
+    typeScope.Pop ();
+  }
+
+  void InsertFunction (std::string ident, AST::Function *fn)
+  {
+    functionScope.Insert (ident, fn);
+  }
+
+  bool LookupFunction (std::string ident, AST::Function **fn)
+  {
+    return functionScope.Lookup (ident, fn);
+  }
+
+  void InsertLocal (std::string ident, AST::LetStmt *let)
+  {
+    localsPerBlock.Insert (ident, let);
+  }
+
+  bool LookupLocal (std::string ident, AST::LetStmt **let)
+  {
+    return localsPerBlock.Lookup (ident, let);
+  }
+
+  std ::map<std::string, AST::LetStmt *> PeekLocals ()
+  {
+    return localsPerBlock.Peek ();
+  }
+
+  void InsertStruct (std::string ident, AST::StructStruct *s)
+  {
+    structsPerBlock.Insert (ident, s);
+  }
+
+  bool LookupStruct (std::string ident, AST::StructStruct **s)
+  {
+    return structsPerBlock.Lookup (ident, s);
+  }
+
+  void InsertType (std::string ident, AST::Type *s)
+  {
+    typeScope.Insert (ident, s);
+  }
+
+  bool LookupType (std::string ident, AST::Type **s)
+  {
+    return typeScope.Lookup (ident, s);
+  }
+
+private:
+  Scope<AST::Function *> functionScope;
+  Scope<AST::LetStmt *> localsPerBlock;
+  Scope<AST::StructStruct *> structsPerBlock;
+  Scope<AST::Type *> typeScope;
+};
+
 class TypeResolution : public Resolution
 {
+  friend class TypeScoping;
+
 public:
   ~TypeResolution ();
   static bool Resolve (AST::Crate &crate, TopLevelScan &toplevel);
@@ -223,9 +300,7 @@ private:
   AST::Function *lookupFndecl (AST::Expr *expr);
   bool isTypeInScope (AST::Type *type, Location locus);
 
-  Scope<AST::Function *> functionScope;
-  Scope<AST::LetStmt *> localsPerBlock;
-  Scope<AST::StructStruct *> structsPerBlock;
+  TypeScoping scope;
 };
 
 } // namespace Analysis

--- a/gcc/rust/analysis/rust-type-resolution.h
+++ b/gcc/rust/analysis/rust-type-resolution.h
@@ -225,6 +225,7 @@ private:
 
   Scope<AST::Function *> functionScope;
   Scope<AST::LetStmt *> localsPerBlock;
+  Scope<AST::StructStruct *> structsPerBlock;
 };
 
 } // namespace Analysis

--- a/gcc/rust/analysis/scope.h
+++ b/gcc/rust/analysis/scope.h
@@ -47,6 +47,8 @@ public:
     return toplevel;
   }
 
+  std ::map<std::string, T> Peek () { return scopeStack.back (); }
+
 private:
   std::vector<std::map<std::string, T> > scopeStack;
 };

--- a/gcc/rust/ast/rust-item.h
+++ b/gcc/rust/ast/rust-item.h
@@ -1577,7 +1577,7 @@ protected:
 // Rust base struct declaration AST node - abstract base class
 class Struct : public VisItem
 {
-protected:
+public:
   // protected to enable access by derived classes - allows better as_string
   Identifier struct_name;
 
@@ -1590,7 +1590,6 @@ protected:
 
   Location locus;
 
-public:
   // Returns whether struct has generic parameters.
   inline bool has_generics () const { return !generic_params.empty (); }
 
@@ -1653,7 +1652,7 @@ protected:
 // A single field in a struct
 struct StructField
 {
-private:
+public:
   // bool has_outer_attributes;
   ::std::vector<Attribute> outer_attrs;
 
@@ -1666,7 +1665,6 @@ private:
 
   // should this store location info?
 
-public:
   // Returns whether struct field has any outer attributes.
   inline bool has_outer_attributes () const { return !outer_attrs.empty (); }
 
@@ -1725,10 +1723,10 @@ public:
 // Rust struct declaration with true struct type AST node
 class StructStruct : public Struct
 {
+public:
   ::std::vector<StructField> fields;
   bool is_unit;
 
-public:
   ::std::string as_string () const;
 
   // Mega-constructor with all possible fields


### PR DESCRIPTION
This refactors some of the type resolution scoping code and adds compilation to create a GCC record type out of a simple struct.