### PR TITLE
Compile AST::StructExprStructFields into a constructor tree.

### DIFF
--- a/gcc/rust/backend/cscope.h
+++ b/gcc/rust/backend/cscope.h
@@ -19,6 +19,7 @@ public:
     fndecls.Push ();
     vars.Push ();
     types.Push ();
+    structDecls.Push ();
   }
 
   void Pop ()
@@ -26,6 +27,7 @@ public:
     fndecls.Pop ();
     vars.Pop ();
     types.Pop ();
+    structDecls.Pop ();
   }
 
   void PushCurrentFunction (std::string name, Bfunction *fn, Btype *retType,
@@ -85,6 +87,16 @@ public:
 
   void AddStatement (Bstatement *stmt) { context.back ().push_back (stmt); }
 
+  void InsertStructDecl (std::string name, AST::StructStruct *decl)
+  {
+    structDecls.Insert (name, decl);
+  }
+
+  bool LookupStructDecl (std::string name, AST::StructStruct **decl)
+  {
+    return structDecls.Lookup (name, decl);
+  }
+
   void InsertFunction (std::string name, Bfunction *fn, Btype *retType)
   {
     fndecls.Insert (name, fn);
@@ -123,6 +135,7 @@ private:
   Analysis::Scope<Bfunction *> fndecls;
   Analysis::Scope<Bvariable *> vars;
   Analysis::Scope<Btype *> types;
+  Analysis::Scope<AST::StructStruct *> structDecls;
 };
 
 } // namespace Compile

--- a/gcc/rust/backend/rust-compile.h
+++ b/gcc/rust/backend/rust-compile.h
@@ -242,6 +242,8 @@ private:
   std::vector<AST::IdentifierPattern> patternBuffer;
   std::vector< ::Bexpression *> exprs;
   std::vector< ::Bstatement *> stmts;
+  std::vector< ::Bvariable *> varBuffer;
+  std::vector<AST::StructStruct*> structBuffer;
 
   // careful these are the vectors we pass into the GCC middle-end
   std::vector< ::Btype *> type_decls;


### PR DESCRIPTION
This still requires more type resolution work to ensure field ordering
on the initilizer and defaults if required.

struct Foo struct_test;
try
  {
    struct_test.one = 1;
    struct_test.two = 2;
  }
finally
  {
    struct_test = {CLOBBER};
  }